### PR TITLE
Likely issue in _validate_nested_list_type

### DIFF
--- a/pypif/obj/common/pio.py
+++ b/pypif/obj/common/pio.py
@@ -145,4 +145,5 @@ class Pio(object):
             if not isinstance(obj, list):
                 raise TypeError(self.__class__.__name__ + '.' + name + ' contains value of type ' +
                                 type(obj).__name__ + ' where a list is expected')
-            self._validate_nested_list_type(name, obj, nested_level - 1, *args)
+            for sub_obj in obj:
+                self._validate_nested_list_type(name, sub_obj, nested_level - 1, *args)


### PR DESCRIPTION
I ran into an issue setting the "matrices" field of a Value object with a 2D nested list (e.g., Value(matrices=[[1,0],[0,1]]). 

From what I could tell, the problem was in the _validate_nested_list_type operation. Rather than calling the _validate funciton recursively on each of the nested list objects, the function was calling itself with the same object originally passed to the function as input. 

This change iterates through each of the nest objects on each call, and does allow the matrices field to be set.
