### PR TITLE
Adding ReadView to index a Pio object

### DIFF
--- a/pypif/obj/system/tests/test_system.py
+++ b/pypif/obj/system/tests/test_system.py
@@ -1,0 +1,12 @@
+from pypif.obj import System, Property
+
+def test_create_system():
+    pif = System()
+    pif.uid = "10245"
+    pif.names = ["example", "ex"]
+
+def test_convert_to_dictionary():
+    pif = System()
+    pif.uid = "10245"
+    pif.names = ["example", "ex"]
+    d = pif._convert_to_dictionary(pif)

--- a/pypif/util/read_view.py
+++ b/pypif/util/read_view.py
@@ -1,0 +1,49 @@
+from pypif.obj.common.property import Property
+from pypif.obj.common.quantity import Quantity
+from pypif.obj.common.display_item import DisplayItem 
+from pypif.obj.common.id import Id
+from pypif.obj.common.instrument import Instrument
+from pypif.obj.common.license import License
+from pypif.obj.common.method import Method
+from pypif.obj.common.software import Software
+from pypif.obj.common.source import Source
+from pypif.obj.common.value import Value
+from pypif.obj.common.reference import Reference
+from pypif.obj import System as subsystem
+
+class ReadView():
+
+    def __init__(self, system):
+        self.inlines = [
+            (subsystem, "uid"),
+            (Property, "name"),
+            (Quantity, "name"),
+            (Id, "name"),
+            (Instrument, "name"),
+            (License, "name"),
+            (Method, "name"),
+            (Value, "name"),
+            (Software, "name"),
+            (Source, "producer"),
+            (DisplayItem, "title"),
+            (Reference, "doi"),
+        ]
+
+        for k in system.__dict__:
+            added = False
+            if isinstance(getattr(system, k), list):
+                for t, name in self.inlines:
+                    if isinstance(getattr(system, k)[0], t):
+                        setattr(self, k[1:], {getattr(x, name) : ReadView(x) for x in getattr(system, k)})
+                        added = True
+                        break
+                if not added:
+                    setattr(self, k[1:], getattr(system, k))
+            else:
+                for t, name in self.inlines:
+                    if isinstance(getattr(system, k), t):
+                        setattr(self, k[1:], {getattr(system, k)[name] : ReadView(getattr(system, k))})
+                        added = True
+                        break
+                if not added:
+                    setattr(self, k[1:], getattr(system, k))

--- a/pypif/util/read_view.py
+++ b/pypif/util/read_view.py
@@ -9,26 +9,63 @@ from pypif.obj.common.software import Software
 from pypif.obj.common.source import Source
 from pypif.obj.common.value import Value
 from pypif.obj.common.reference import Reference
-from pypif.obj import System as subsystem
+from pypif.obj import System as Subsystem
+
 
 def new_keypair(key, value, ambig, unambig):
+    """
+    Check new keypair against existing unambiguous dict
+
+    :param key: of pair
+    :param value: of pair
+    :param ambig: set of keys with ambig decoding
+    :param unambig: set of keys with unambig decoding
+    :return:
+    """
     if key in ambig:
         return
 
     if key in unambig:
-        ambig.append(key)
-        unambig.remove(key)
+        ambig.add(key)
+        del unambig[key]
         return
 
     unambig[key] = value
     return
 
 
+def add_child_ambig(child_ambig, child_unambig, ambig, unambig):
+    """
+    Add information about decodings of a child object
+
+    :param child_ambig: ambiguous set from child
+    :param child_unambig: unambiguous set from child
+    :param ambig: set of keys storing ambig decodings
+    :param unambig: dictionary storing unambiguous decodings
+    :return:
+    """
+    for k in child_ambig:
+        ambig.add(k)
+        del unambig[k]
+
+    for k, v in child_unambig.items():
+        new_keypair(k, v, ambig, unambig)
+
+    return
+
+
 class ReadView():
 
     def __init__(self, system):
+        """
+        Setup a ReadView by recursing through the pif objects
+
+        :param system: to process into a ReadView; doesn't need to be a system
+        """
+
+        # List of classes to generate an index from
         self.inlines = [
-            (subsystem, "uid"),
+            (Subsystem, "uid"),
             (Property, "name"),
             (Quantity, "name"),
             (Id, "name"),
@@ -42,39 +79,45 @@ class ReadView():
             (Reference, "doi"),
         ]
 
-        def foo_foo(gah, gahh):
-            print("bar")
-
+        # dictionary of unambiguous short keys
         self.unambig = {}
+        # set of keys where there is ambiguity
         self.ambig = set()
 
+        # iterate over the members of the system
         for k in system.__dict__:
             added = False
+
+            # check if list
             if isinstance(getattr(system, k), list):
                 for t, name in self.inlines:
+                    # check if we know how to decode the type
                     if isinstance(getattr(system, k)[0], t):
+                        # populate a dictionary
                         parsed = {}
                         for x in getattr(system, k):
+                            # define a key
                             new_key = getattr(x, name)
                             new_val = ReadView(x)
                             parsed[new_key] = new_val
                             new_keypair(new_key, new_val, self.ambig, self.unambig)
-                            for kk, vv in new_val.unambig.items():
-                                new_keypair(kk, vv, self.ambig, self.unambig)
+                            add_child_ambig(new_val.ambig, new_val.unambig, self.ambig, self.unambig)
+                        # set the property in the readview to point to the dictionary
                         setattr(self, k[1:], parsed)
                         added = True
                         break
                 if not added:
+                    # just mirror the property
                     setattr(self, k[1:], getattr(system, k))
             else:
+                # Same logic as above, but not wrapped in a list
                 for t, name in self.inlines:
                     if isinstance(getattr(system, k), t):
                         new_key = getattr(system, k)[name]
                         new_val = ReadView(getattr(system, k))
                         new_keypair(new_key, new_val, self.ambig, self.unambig)
+                        add_child_ambig(new_val.ambig, new_val.unambig, self.ambig, self.unambig)
                         setattr(self, k[1:], {new_key: new_val})
-                        for kk, vv in new_val.unambig.items():
-                            new_keypair(kk, vv, self.ambig, self.unambig)
                         added = True
                         break
                 if not added:

--- a/pypif/util/tests/test_read_view.py
+++ b/pypif/util/tests/test_read_view.py
@@ -11,8 +11,8 @@ def test_read_view():
     r = ReadView(pif)
     assert r.uid == pif.uid
     assert r.names == pif.names
-    assert r.properties["foo"].scalars == 1.0
-    assert r.properties["bar"].scalars == 2.0
+    assert r.properties["foo"].scalars[0].value == 1.0
+    assert r.properties["bar"].scalars[0].value == 2.0
 
 
 def test_unambig():
@@ -20,8 +20,8 @@ def test_unambig():
     pif = System()
     pif.properties = [Property(name="foo", scalars=1.0), Property(name="bar", scalars=2.0)]
     r = ReadView(pif)
-    assert r["foo"].scalars == 1.0
-    assert r["bar"].scalars == 2.0
+    assert r["foo"].scalars[0].value == 1.0
+    assert r["bar"].scalars[0].value == 2.0
 
 
 def test_nested_read_view():
@@ -33,10 +33,10 @@ def test_nested_read_view():
     r = ReadView(pif2)
     assert r.sub_systems["10245"].uid == pif.uid
     assert r["10245"].uid == pif.uid
-    assert r.sub_systems["10245"].properties["foo"].scalars == 1.0
-    assert r.sub_systems["10245"].properties["bar"].scalars == 2.0
-    assert r["foo"].scalars == 1.0
-    assert r["bar"].scalars == 2.0
+    assert r.sub_systems["10245"].properties["foo"].scalars[0].value == 1.0
+    assert r.sub_systems["10245"].properties["bar"].scalars[0].value == 2.0
+    assert r["foo"].scalars[0].value == 1.0
+    assert r["bar"].scalars[0].value == 2.0
 
 
 def test_ambiguity():
@@ -46,11 +46,11 @@ def test_ambiguity():
     pif.properties = [Property(name="foo", scalars=1.0), Property(name="bar", scalars=2.0)]
     pif2 = System(sub_systems = [pif,], properties=[Property(name="foo", scalars=10.0)])
     r = ReadView(pif2)
-    assert r.properties["foo"].scalars == 10.0
-    assert r.sub_systems["10245"].properties["foo"].scalars == 1.0
+    assert r.properties["foo"].scalars[0].value == 10.0
+    assert r.sub_systems["10245"].properties["foo"].scalars[0].value == 1.0
     assert "foo" not in r.keys()
-    assert r.sub_systems["10245"]["foo"].scalars == 1.0
-    assert r["bar"].scalars == 2.0
+    assert r.sub_systems["10245"]["foo"].scalars[0].value == 1.0
+    assert r["bar"].scalars[0].value == 2.0
 
 
 def test_multiple_instances():
@@ -60,6 +60,6 @@ def test_multiple_instances():
     pif.properties = [Property(name="foo", scalars=1.0), Property(name="bar", scalars=2.0)]
     pif2 = System(sub_systems = [pif,], properties=[Property(name="bar", scalars=2.0)])
     r = ReadView(pif2)
-    assert r.properties["bar"].scalars == 2.0
-    assert r.sub_systems["10245"].properties["bar"].scalars == 2.0
-    assert r["bar"].scalars == 2.0
+    assert r.properties["bar"].scalars[0].value == 2.0
+    assert r.sub_systems["10245"].properties["bar"].scalars[0].value == 2.0
+    assert r["bar"].scalars[0].value == 2.0

--- a/pypif/util/tests/test_read_view.py
+++ b/pypif/util/tests/test_read_view.py
@@ -51,3 +51,15 @@ def test_ambiguity():
     assert "foo" not in r.keys()
     assert r.sub_systems["10245"]["foo"].scalars == 1.0
     assert r["bar"].scalars == 2.0
+
+
+def test_multiple_instances():
+    """Test that keys that show up in different places with the same value are kept"""
+    pif = System()
+    pif.uid = "10245"
+    pif.properties = [Property(name="foo", scalars=1.0), Property(name="bar", scalars=2.0)]
+    pif2 = System(sub_systems = [pif,], properties=[Property(name="bar", scalars=2.0)])
+    r = ReadView(pif2)
+    assert r.properties["bar"].scalars == 2.0
+    assert r.sub_systems["10245"].properties["bar"].scalars == 2.0
+    assert r["bar"].scalars == 2.0

--- a/pypif/util/tests/test_read_view.py
+++ b/pypif/util/tests/test_read_view.py
@@ -1,0 +1,27 @@
+from pypif.obj import System, Property
+from pypif.util.read_view import ReadView
+
+def test_read_view():
+    pif = System()
+    pif.uid = "10245"
+    pif.names = ["example", "ex"]
+    pif.properties = [Property(name="foo", scalars=1.0), Property(name="bar", scalars=2.0)]
+    r = ReadView(pif)
+    assert r.uid == pif.uid
+    assert r.names == pif.names
+    assert r.properties["foo"].scalars == 1.0
+    assert r.properties["bar"].scalars == 2.0
+
+def test_nested_read_view():
+    pif = System()
+    pif.uid = "10245"
+    pif.names = ["example", "ex"]
+    pif.properties = [Property(name="foo", scalars=1.0), Property(name="bar", scalars=2.0)]
+    pif2 = System(sub_systems = [pif,])
+    r = ReadView(pif2)
+    assert r.sub_systems["10245"].uid == pif.uid
+    assert r.sub_systems["10245"].names == pif.names
+    assert r.sub_systems["10245"].properties["foo"].scalars == 1.0
+    assert r.sub_systems["10245"].properties["bar"].scalars == 2.0
+
+

--- a/pypif/util/tests/test_read_view.py
+++ b/pypif/util/tests/test_read_view.py
@@ -23,5 +23,7 @@ def test_nested_read_view():
     assert r.sub_systems["10245"].names == pif.names
     assert r.sub_systems["10245"].properties["foo"].scalars == 1.0
     assert r.sub_systems["10245"].properties["bar"].scalars == 2.0
+    assert r["foo"].scalars == 1.0
+    assert r["bar"].scalars == 2.0
 
 

--- a/pypif/util/tests/test_read_view.py
+++ b/pypif/util/tests/test_read_view.py
@@ -1,7 +1,9 @@
 from pypif.obj import System, Property
 from pypif.util.read_view import ReadView
 
+
 def test_read_view():
+    """Test that properties are passed through to the readview"""
     pif = System()
     pif.uid = "10245"
     pif.names = ["example", "ex"]
@@ -12,18 +14,40 @@ def test_read_view():
     assert r.properties["foo"].scalars == 1.0
     assert r.properties["bar"].scalars == 2.0
 
+
+def test_unambig():
+    """Test that properties are mirrored in a top level dic"""
+    pif = System()
+    pif.properties = [Property(name="foo", scalars=1.0), Property(name="bar", scalars=2.0)]
+    r = ReadView(pif)
+    assert r["foo"].scalars == 1.0
+    assert r["bar"].scalars == 2.0
+
+
 def test_nested_read_view():
+    """Test that nested Pios (system here) are recursively processed"""
     pif = System()
     pif.uid = "10245"
-    pif.names = ["example", "ex"]
     pif.properties = [Property(name="foo", scalars=1.0), Property(name="bar", scalars=2.0)]
-    pif2 = System(sub_systems = [pif,])
+    pif2 = System(sub_systems=[pif])
     r = ReadView(pif2)
     assert r.sub_systems["10245"].uid == pif.uid
-    assert r.sub_systems["10245"].names == pif.names
+    assert r["10245"].uid == pif.uid
     assert r.sub_systems["10245"].properties["foo"].scalars == 1.0
     assert r.sub_systems["10245"].properties["bar"].scalars == 2.0
     assert r["foo"].scalars == 1.0
     assert r["bar"].scalars == 2.0
 
 
+def test_ambiguity():
+    """Test that ambiguous keys are removed from the top level dict"""
+    pif = System()
+    pif.uid = "10245"
+    pif.properties = [Property(name="foo", scalars=1.0), Property(name="bar", scalars=2.0)]
+    pif2 = System(sub_systems = [pif,], properties=[Property(name="foo", scalars=10.0)])
+    r = ReadView(pif2)
+    assert r.properties["foo"].scalars == 10.0
+    assert r.sub_systems["10245"].properties["foo"].scalars == 1.0
+    assert "foo" not in r.keys()
+    assert r.sub_systems["10245"]["foo"].scalars == 1.0
+    assert r["bar"].scalars == 2.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pypif',
-      version='1.0.25',
+      version='1.1.0',
       url='http://github.com/CitrineInformatics/pypif',
       description='Python tools for working with the Physical Information File (PIF)',
       author='Kyle Michel',


### PR DESCRIPTION
The helper object allows `Pio` objects to be index as `r.properties["bar"].scalars`

CC: @kjaym 