### PR TITLE
Check classification field against Classification type, not Id type

### DIFF
--- a/pypif/obj/system/system.py
+++ b/pypif/obj/system/system.py
@@ -106,7 +106,7 @@ class System(Rcl):
 
     @classifications.setter
     def classifications(self, classifications):
-        self._validate_list_type('classifications', classifications, dict, string_types, numbers.Number, Id)
+        self._validate_list_type('classifications', classifications, dict, string_types, numbers.Number, Classification)
         self._classifications = self._get_object(Classification, classifications)
 
     @ids.deleter


### PR DESCRIPTION
@maxhutch @joannehill This fixes a bug that values in the `System.classifications` field were checked against the `Id` type rather than `Classification`.