### PR TITLE
2.0.1: loosen six requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(name='pypif',
       author_email='kyle@citrine.io',
       packages=find_packages(),
       install_requires=[
-            'six==1.10.0'
+            'six>=1.10.0'
       ])

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(name='pypif',
       author_email='kyle@citrine.io',
       packages=find_packages(),
       install_requires=[
-            'six>=1.10.0'
+            'six>=1.10.0,<2'
       ])


### PR DESCRIPTION
We had a requirement of six==1.10.0 in setup.py. This just loosens the requirement to anything greater than or equal to that version.