### PR TITLE
Python 3 compatibility

### DIFF
--- a/pypif/util/pif_encoder.py
+++ b/pypif/util/pif_encoder.py
@@ -1,4 +1,5 @@
 import json
+import collections
 
 
 class PifEncoder(json.JSONEncoder):
@@ -16,7 +17,7 @@ class PifEncoder(json.JSONEncoder):
         """
         if obj is None:
             return []
-        elif isinstance(obj, list):
+        elif isinstance(obj, collections.Iterable):
             return [i.as_dictionary() for i in obj]
         else:
             return obj.as_dictionary()

--- a/pypif/util/serializable.py
+++ b/pypif/util/serializable.py
@@ -1,3 +1,4 @@
+import collections
 from pypif.util.case import to_camel_case
 from pypif.util.case import keys_to_snake_case
 
@@ -25,12 +26,12 @@ class Serializable(object):
         :param obj: Object to convert to a dictionary.
         :returns: Input object as a dictionary or the original object.
         """
-        if isinstance(obj, list):
+        if isinstance(obj, collections.Iterable) and not isinstance(obj, str):
             return [Serializable._convert_to_dictionary(i) for i in obj]
         elif hasattr(obj, 'as_dictionary'):
             return obj.as_dictionary()
         else:
-            return obj
+            return str(obj)
 
     @staticmethod
     def _get_object(class_, obj):
@@ -41,7 +42,7 @@ class Serializable(object):
         :param obj: Object to process.
         :return: One or more objects.
         """
-        if isinstance(obj, list):
+        if isinstance(obj, collections.Iterable) and not isinstance(obj, str):
             return [Serializable._get_object(class_, i) for i in obj]
         elif isinstance(obj, dict):
             return class_(**keys_to_snake_case(obj))


### PR DESCRIPTION
Changes:
* Match on iterable types (excluding strings) instead of only lists. 
* Return leaf objects as a string when converting object to a dictionary.

The latter lead to failures in Python 3.7. We will need to cut a new release and pull this into `data-examples` (see [#26](https://github.com/CitrineInformatics/data-examples/pull/26)) for that repo to work in Python 3.