### PR TITLE
Bugfix/encode numpy values

### DIFF
--- a/pypif/tests/test_pif.py
+++ b/pypif/tests/test_pif.py
@@ -1,6 +1,8 @@
-from pypif.pif import loads, dumps
-from pypif.obj.system import System
+import numpy as np
+
 from pypif.obj.common import Property, Scalar, FileReference, ProcessStep, Value, Person, Name
+from pypif.obj.system import System
+from pypif.pif import loads, dumps
 
 
 def test_basic_round_robin():
@@ -13,8 +15,8 @@ def test_basic_round_robin():
 def test_full_round_robin():
     pif = System(
         properties=[
-            Property(name="foo", scalars=[Scalar(value=2.4), Scalar(value=2.5)]),
-            Property(name="bar", scalars=[Scalar(value=2.4)]),
+            Property(name="foo", scalars=[Scalar(value=np.float32(2.4)), Scalar(value=np.int64(2))]),
+            Property(name="bar", scalars=[Scalar(value=2.4), Scalar(value=2)]),
             Property(name="spam", files=[FileReference(relative_path="/tmp/file")])
         ],
         preparation=[ProcessStep(name="processed", details=[Value(name="temp", scalars=[Scalar(value=1.0)])])],

--- a/pypif/util/pif_encoder.py
+++ b/pypif/util/pif_encoder.py
@@ -1,5 +1,7 @@
 import json
 
+import numpy as np
+
 
 class PifEncoder(json.JSONEncoder):
     """
@@ -18,5 +20,11 @@ class PifEncoder(json.JSONEncoder):
             return []
         elif isinstance(obj, list):
             return [i.as_dictionary() for i in obj]
-        else:
+        elif hasattr(obj, 'as_dictionary'):
             return obj.as_dictionary()
+        elif isinstance(obj, (np.int_, np.intc, np.intp, np.int8, np.int16, np.int32,
+                              np.int64, np.uint8, np.uint16, np.uint32, np.uint64)):
+            return int(obj)
+        elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
+            return float(obj)
+        return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
Added support to encode numpy `int`s and `float`s. This lead to failures in Python 3.7.